### PR TITLE
Fix the composer provide rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "mockery/mockery": "1.0"
     },
     "provide": {
-        "psr/http-server-handler": "^1.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-handler-implementation": "1.0",
+        "psr/http-server-middleware-implementation": "1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package does not provide the code of the psr interface packages. It provides implementations of the interfaces and so should provide the virtual packages representing implementations of the interface.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that installing the psr packages is not necessary as they are already provided.

Refs composer/composer#9316 (not the same package than the one mentioned in the bug report, but same issue)